### PR TITLE
Add optional parameter to configure LO offset (for TX)

### DIFF
--- a/cloudlogcatqt.h
+++ b/cloudlogcatqt.h
@@ -73,8 +73,10 @@ private:
     QNetworkAccessManager *frequencyManager;
     QNetworkAccessManager *modeManager;
     QNetworkAccessManager *cloudLogManager;
-    QString frequency;
+    double frequency;
+    double realFrequency;
     QString mode;
+    double txOffset;
 
     QString settingsFile;
 

--- a/cloudlogcatqt.ui
+++ b/cloudlogcatqt.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>300</height>
+    <height>369</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -40,7 +40,7 @@
        <bool>false</bool>
       </property>
       <property name="digitCount">
-       <number>9</number>
+       <number>12</number>
       </property>
       <property name="segmentStyle">
        <enum>QLCDNumber::Filled</enum>
@@ -74,7 +74,20 @@
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::ExpandingFieldsGrow</enum>
       </property>
+      <property name="formAlignment">
+       <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
+      </property>
       <item row="0" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>TX LO Offset (Hz):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="TXOffset"/>
+      </item>
+      <item row="1" column="0">
        <widget class="QLabel" name="label_1">
         <property name="maximumSize">
          <size>
@@ -87,7 +100,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QLineEdit" name="FLRigHostname">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -100,7 +113,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_2">
         <property name="maximumSize">
          <size>
@@ -113,14 +126,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QLineEdit" name="FLRigPort">
         <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_3">
         <property name="maximumSize">
          <size>
@@ -133,14 +146,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QLineEdit" name="cloudLogUrl">
         <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_4">
         <property name="maximumSize">
          <size>
@@ -159,7 +172,7 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QLineEdit" name="cloudLogKey">
         <property name="text">
          <string/>


### PR DESCRIPTION
I use CloudLogQt for logging QO-100 SAT QSOs to Cloudlog. The setup usually involves transmitting on some IF which is up/down converted to the real output frequency in order to reach the satellite. In this case for example 430 MHz -> 2400MHz for QO-100. Therefore it would be good to be able to add (or substract) the LO frequency of the converter to the IF before uploading to Cloudlog (or displaying in the UI). This is a patch to achieve that.

![Screenshot from 2021-11-11 12-28-53](https://user-images.githubusercontent.com/7112907/141292022-0603b2b0-7c01-4cc0-8d37-74a4a79c650f.png)
