### PR TITLE
Add RX freq offset (calculated from TX)

### DIFF
--- a/cloudlogcatqt.h
+++ b/cloudlogcatqt.h
@@ -74,9 +74,11 @@ private:
     QNetworkAccessManager *modeManager;
     QNetworkAccessManager *cloudLogManager;
     double frequency;
-    double realFrequency;
+    double realTxFrequency;
+    double realRxFrequency;
     QString mode;
     double txOffset;
+    double rxOffset;
 
     QString settingsFile;
 

--- a/cloudlogcatqt.ui
+++ b/cloudlogcatqt.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>369</height>
+    <height>404</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -69,7 +69,7 @@
       </property>
      </widget>
     </item>
-    <item row="3" column="0">
+    <item row="2" column="0" rowspan="2">
      <layout class="QFormLayout" name="Config">
       <property name="fieldGrowthPolicy">
        <enum>QFormLayout::ExpandingFieldsGrow</enum>
@@ -77,17 +77,17 @@
       <property name="formAlignment">
        <set>Qt::AlignBottom|Qt::AlignLeading|Qt::AlignLeft</set>
       </property>
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="label_5">
         <property name="text">
-         <string>TX LO Offset (Hz):</string>
+         <string>RX LO Offset (Hz):</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="TXOffset"/>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="RXOffset"/>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="label_1">
         <property name="maximumSize">
          <size>
@@ -100,7 +100,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QLineEdit" name="FLRigHostname">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -113,7 +113,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_2">
         <property name="maximumSize">
          <size>
@@ -126,14 +126,14 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QLineEdit" name="FLRigPort">
         <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_3">
         <property name="maximumSize">
          <size>
@@ -146,14 +146,14 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QLineEdit" name="cloudLogUrl">
         <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="label_4">
         <property name="maximumSize">
          <size>
@@ -172,10 +172,20 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QLineEdit" name="cloudLogKey">
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="TXOffset"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>TX LO Offset (Hz)</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Can we have a second offset for RX so that cross-band QSOs (e.g. QO-100) are logged correctly?

![Screenshot from 2022-09-19 16-49-48](https://user-images.githubusercontent.com/7112907/191046649-99248e16-7cd1-47f3-a278-e830cc6deb87.png)
