### PR TITLE
Add editable identifier

### DIFF
--- a/cloudlogcatqt.cpp
+++ b/cloudlogcatqt.cpp
@@ -193,6 +193,7 @@ void CloudLogCATQt::uploadToCloudLog()
                 + "{"
                 + "\"key\" : \"" + ui->cloudLogKey->text() + "\","
                 + "\"radio\" : \"CloudLogCATQt\" ,"
+                + "\"identifier\" : \"" + ui->cloudLogIdentifier->text() + "\","
                 + "\"prop_mode\" : \"" + propMode[0] + "\",";
     		if (propMode[0] == "SAT") {
 			str += "\"sat_name\" : \"" + satellite[0] + "\","
@@ -235,6 +236,7 @@ void CloudLogCATQt::loadSettings()
 
     ui->cloudLogUrl->setText(settings.value("cloudLogUrl","").toString());
     ui->cloudLogKey->setText(settings.value("cloudLogKey","").toString());
+    ui->cloudLogIdentifier->setText(settings.value("cloudLogIdentifier","").toString());
     ui->FLRigHostname->setText(settings.value("FLRigHostname", "localhost").toString());
     ui->FLRigPort->setText(settings.value("FLRigPort", "12345").toString());
     ui->TXOffset->setText(settings.value("TXOffset", "0").toString());
@@ -354,15 +356,16 @@ void CloudLogCATQt::on_save_clicked()
     QStringList propMode = propModeDesc.split('|');
     satelliteDesc = ui->satellite->currentText();
     QStringList satellite = satelliteDesc.split('|');
-    settings.setValue("cloudLogUrl",   ui->cloudLogUrl->text());
-    settings.setValue("cloudLogKey",   ui->cloudLogKey->text());
-    settings.setValue("FLRigHostname", ui->FLRigHostname->text());
-    settings.setValue("FLRigPort",     ui->FLRigPort->text());
-    settings.setValue("TXOffset",      ui->TXOffset->text());
-    settings.setValue("RXOffset",      ui->RXOffset->text());
-    settings.setValue("Power",         ui->Power->text());
-    settings.setValue("PropMode",      propMode[0]);
-    settings.setValue("Sat",           satellite[0]);
+    settings.setValue("cloudLogUrl",         ui->cloudLogUrl->text());
+    settings.setValue("cloudLogKey",         ui->cloudLogKey->text());
+    settings.setValue("cloudLogIdentifier",  ui->cloudLogIdentifier->text());
+    settings.setValue("FLRigHostname",       ui->FLRigHostname->text());
+    settings.setValue("FLRigPort",           ui->FLRigPort->text());
+    settings.setValue("TXOffset",            ui->TXOffset->text());
+    settings.setValue("RXOffset",            ui->RXOffset->text());
+    settings.setValue("Power",               ui->Power->text());
+    settings.setValue("PropMode",            propMode[0]);
+    settings.setValue("Sat",                 satellite[0]);
     txOffset = ui->TXOffset->text().toDouble();
     rxOffset = ui->RXOffset->text().toDouble();
 }

--- a/cloudlogcatqt.cpp
+++ b/cloudlogcatqt.cpp
@@ -145,6 +145,24 @@ CloudLogCATQt::CloudLogCATQt(QWidget *parent)
 
     // Set Status Bar
     ui->statusbar->showMessage("(c) 2020 DL9MJ");
+
+    // Set Placeholders
+    ui->cloudLogUrl->setPlaceholderText("https://yourdomain.com/index.php/api/radio");
+    ui->cloudLogKey->setPlaceholderText("cl632adab771259");
+    ui->cloudLogIdentifier->setPlaceholderText("Rig Name");
+    ui->FLRigHostname->setPlaceholderText("localhost");
+    ui->FLRigPort->setPlaceholderText("12345");
+    ui->TXOffset->setPlaceholderText("0");
+    ui->RXOffset->setPlaceholderText("0");
+
+    // Set Input Constraints
+    QRegExp identifierRe("[ \\w\\d-_#]{0,50}");
+    QRegExpValidator *idValidator = new QRegExpValidator(identifierRe, this);
+    ui->cloudLogIdentifier->setValidator(idValidator);
+    QRegExp loRe("\\d*");
+    QRegExpValidator *loValidator = new QRegExpValidator(loRe, this);
+    ui->TXOffset->setValidator(loValidator);
+    ui->RXOffset->setValidator(loValidator);
 }
 
 CloudLogCATQt::~CloudLogCATQt()
@@ -191,28 +209,28 @@ void CloudLogCATQt::uploadToCloudLog()
     satellite = satelliteDesc.split('|');
     QString str = QString("")
                 + "{"
-                + "\"key\" : \"" + ui->cloudLogKey->text() + "\","
+                + "\"key\" : \"" + ui->cloudLogKey->text() + "\" ,"
                 + "\"radio\" : \"CloudLogCATQt\" ,"
-                + "\"identifier\" : \"" + ui->cloudLogIdentifier->text() + "\","
-                + "\"prop_mode\" : \"" + propMode[0] + "\",";
+                + "\"identifier\" : \"" + ui->cloudLogIdentifier->text() + "\" ,"
+                + "\"prop_mode\" : \"" + propMode[0] + "\" ,";
     		if (propMode[0] == "SAT") {
-			str += "\"sat_name\" : \"" + satellite[0] + "\","
-                            + "\"uplink_freq\" : \"" + QString{ "%1" }.arg( realTxFrequency, 1, 'f', 0) + "\","
-                            + "\"uplink_mode\" : \"" + mode + "\","
-                            + "\"downlink_freq\" : \"" + QString{ "%1" }.arg( realRxFrequency, 1, 'f', 0) + "\","
-                            + "\"downlink_mode\" : \"" + mode + "\","
-                            + "\"frequency\" : \"NULL\","
-                            + "\"mode\" : \"NULL\",";
+			str += "\"sat_name\" : \"" + satellite[0] + "\" ,"
+                            + "\"uplink_freq\" : \"" + QString{ "%1" }.arg( realTxFrequency, 1, 'f', 0) + "\" ,"
+                            + "\"uplink_mode\" : \"" + mode + "\" ,"
+                            + "\"downlink_freq\" : \"" + QString{ "%1" }.arg( realRxFrequency, 1, 'f', 0) + "\" ,"
+                            + "\"downlink_mode\" : \"" + mode + "\" ,"
+                            + "\"frequency\" : \"NULL\" ,"
+                            + "\"mode\" : \"NULL\" ,";
 		} else {
-			str += "\"sat_name\" : \"" + satellite[0] + "\","
-                            + "\"uplink_freq\" : \"NULL\","
-                            + "\"uplink_mode\" : \"NULL\","
-                            + "\"downlink_freq\" : \"NULL\","
-                            + "\"downlink_mode\" : \"NULL\","
-                            + "\"frequency\" : \"" + QString{ "%1" }.arg( realTxFrequency, 1, 'f', 0) + "\","
-                            + "\"mode\" : \"" + mode + "\",";
+			str += "\"sat_name\" : \"" + satellite[0] + "\" ,"
+                            + "\"uplink_freq\" : \"NULL\" ,"
+                            + "\"uplink_mode\" : \"NULL\" ,"
+                            + "\"downlink_freq\" : \"NULL\" ,"
+                            + "\"downlink_mode\" : \"NULL\" ,"
+                            + "\"frequency\" : \"" + QString{ "%1" }.arg( realTxFrequency, 1, 'f', 0) + "\" ,"
+                            + "\"mode\" : \"" + mode + "\" ,";
 		}
-		str += "\"power\" : \"" + QString{ "%1" }.arg(power) + "\","
+		str += "\"power\" : \"" + QString{ "%1" }.arg(power) + "\" ,"
                 + "\"timestamp\" : \"" + currentTime.toString("yyyy/MM/dd hh:mm") + "\""
                 + "}";
     data = str.toUtf8();

--- a/cloudlogcatqt.ui
+++ b/cloudlogcatqt.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>415</width>
-    <height>471</height>
+    <height>515</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -239,6 +239,16 @@
        <widget class="QLineEdit" name="cloudLogKey">
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QLineEdit" name="cloudLogIdentifier"/>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Cloudlog Identifier:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This adds a user-editable field and allows for multiple instances of CloudLogCatQt to run in parallel without overwriting each other. This is work in progress as the input field needs some constraints to be added such that only text and some special characters can be entered. Basic functionality however is given. The corresponding change to Cloudlog is handled in https://github.com/magicbug/Cloudlog/pull/1611. Looking forward to testers and their feedback.

![Screenshot from 2022-09-20 22-58-49](https://user-images.githubusercontent.com/7112907/191364332-f58a543f-71c7-432e-b69c-2cbf68656c23.png)
