### PR TITLE
Refactor CAT interface to comply with Cloudlog V2

### DIFF
--- a/cloudlogcatqt.ui
+++ b/cloudlogcatqt.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>415</width>
-    <height>471</height>
+    <height>515</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -239,6 +239,16 @@
        <widget class="QLineEdit" name="cloudLogKey">
         <property name="text">
          <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="9" column="1">
+       <widget class="QLineEdit" name="cloudLogIdentifier"/>
+      </item>
+      <item row="9" column="0">
+       <widget class="QLabel" name="label_10">
+        <property name="text">
+         <string>Cloudlog Identifier:</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This updates CloudLogCatQt to cope with the latest changes in Cloudlog's API that where introduced by @kb-light. See https://github.com/magicbug/Cloudlog/pull/1582.

Squashed commit of the following:

commit 125fac83c0410adddcbec857ea6dd1d8a2bf234e
Author: Florian Wolters <github@florian-wolters.de>
Date:   Thu Sep 29 13:20:20 2022 +0200

    Remove separate uplink values for frequency and mode

commit b9f38c7efd3c7228b3b8ea2ed11fc3110c3ad293
Author: Florian Wolters <github@florian-wolters.de>
Date:   Thu Sep 29 11:54:09 2022 +0200

    Prevent upload until nec. varialbes are set

commit 906979fce404bc3674c5426e5915e23daf1dea07
Author: Florian Wolters <github@florian-wolters.de>
Date:   Wed Sep 21 11:40:24 2022 +0200

    Set placeholders and input contraints

commit 597e0ddeb3f47753d0c1b8e5cd9a0406b7821c16
Author: Florian Wolters <github@florian-wolters.de>
Date:   Tue Sep 20 22:43:36 2022 +0200

    Add editable identifier