### PR TITLE
Fix problem where settings were not saved to an INI file in a Windows environment

### DIFF
--- a/cloudlogcatqt.cpp
+++ b/cloudlogcatqt.cpp
@@ -231,7 +231,7 @@ void CloudLogCATQt::uploadToCloudLog()
 void CloudLogCATQt::loadSettings()
 {
     qDebug() << "LOAD";
-    QSettings settings(settingsFile, QSettings::NativeFormat);
+    QSettings settings(settingsFile, QSettings::IniFormat);
 
     ui->cloudLogUrl->setText(settings.value("cloudLogUrl","").toString());
     ui->cloudLogKey->setText(settings.value("cloudLogKey","").toString());
@@ -348,7 +348,7 @@ void CloudLogCATQt::getMode()
 void CloudLogCATQt::on_save_clicked()
 {
     qDebug() << "SAVE";
-    QSettings settings(settingsFile, QSettings::NativeFormat);
+    QSettings settings(settingsFile, QSettings::IniFormat);
 
     propModeDesc = ui->propMode->currentText();
     QStringList propMode = propModeDesc.split('|');


### PR DESCRIPTION
This solves a problem in Windows 10 environments, where an `INI` file were not created when saving teh settings. 

As the documentation for [QSettings](https://doc.qt.io/qt-5/qsettings.html#QSettings-3) states, there should also no problem on UNIX or macOS when using `QSettings::IniFormat`. The only side effect that might occur is, that all settings have to be set again.