### PR TITLE
add mode override to use for digi modes like FT8

### DIFF
--- a/cloudlogcatqt.cpp
+++ b/cloudlogcatqt.cpp
@@ -247,7 +247,7 @@ void CloudLogCATQt::uploadToCloudLog()
     cloudLogManager->post(request, data);
 
     qDebug() << "Update Cloud Log: " << data;
-    ui->statusbar->showMessage(modeToSend + " Cloudlog Updated: "
+    ui->statusbar->showMessage("Cloudlog Updated: "
                                + currentTime.toString("yyyy/MM/dd hh:mm:ss")
                                + " | (c) 2020 DL9MJ");
 }

--- a/cloudlogcatqt.cpp
+++ b/cloudlogcatqt.cpp
@@ -69,6 +69,12 @@ CloudLogCATQt::CloudLogCATQt(QWidget *parent)
                      SLOT(callbackPower())
     );
 
+    QObject::connect(ui->ModeOverride,
+                     SIGNAL(textChanged(QString)),
+                     this,
+                     SLOT(callbackModeOverride())
+    );
+
     QObject::connect(ui->propMode,
 		    SIGNAL(currentTextChanged(QString)),
 		    this,
@@ -203,11 +209,17 @@ QString CloudLogCATQt::parseXML(QString xml)
 void CloudLogCATQt::uploadToCloudLog()
 {
     // Prevent upload until variables are set
-    if (ui->cloudLogKey->text() == "" || mode == "") {
+    if (ui->cloudLogKey->text() == "" || (mode == "" && modeOverride == "")) {
         return;
     }
     QDateTime currentTime = QDateTime::currentDateTime();
     QByteArray data;
+
+    // check for mode override
+    QString modeToSend = mode;
+    if (modeOverride != "") {
+        modeToSend = modeOverride;
+    }
 
     propMode = propModeDesc.split('|');
     satellite = satelliteDesc.split('|');
@@ -217,11 +229,11 @@ void CloudLogCATQt::uploadToCloudLog()
                 + "\"radio\" : \"CloudLogCATQt (" + ui->cloudLogIdentifier->text() + ")\" ,"
                 + "\"prop_mode\" : \"" + propMode[0] + "\" ,"
                 + "\"frequency\" : \"" + QString{ "%1" }.arg( realTxFrequency, 1, 'f', 0) + "\" ,"
-                + "\"mode\" : \"" + mode + "\" ,";
+                + "\"mode\" : \"" + modeToSend + "\" ,";
     		if (propMode[0] == "SAT") {
 			str += "\"sat_name\" : \"" + satellite[0] + "\" ,"
                             + "\"frequency_rx\" : \"" + QString{ "%1" }.arg( realRxFrequency, 1, 'f', 0) + "\" ,"
-                            + "\"mode_rx\" : \"" + mode + "\" ,";
+                            + "\"mode_rx\" : \"" + modeToSend + "\" ,";
 		}
 		str += "\"power\" : \"" + QString{ "%1" }.arg(power) + "\" ,"
                 + "\"timestamp\" : \"" + currentTime.toString("yyyy/MM/dd hh:mm") + "\""
@@ -235,7 +247,7 @@ void CloudLogCATQt::uploadToCloudLog()
     cloudLogManager->post(request, data);
 
     qDebug() << "Update Cloud Log: " << data;
-    ui->statusbar->showMessage("Cloudlog Updated: "
+    ui->statusbar->showMessage(modeToSend + " Cloudlog Updated: "
                                + currentTime.toString("yyyy/MM/dd hh:mm:ss")
                                + " | (c) 2020 DL9MJ");
 }
@@ -312,6 +324,12 @@ void CloudLogCATQt::callbackCloudLog(QNetworkReply *rep)
 void CloudLogCATQt::callbackPower()
 {
     power = ui->Power->value();
+    uploadToCloudLog();
+}
+
+void CloudLogCATQt::callbackModeOverride()
+{
+    modeOverride = ui->ModeOverride->text();
     uploadToCloudLog();
 }
 

--- a/cloudlogcatqt.h
+++ b/cloudlogcatqt.h
@@ -59,6 +59,7 @@ private slots:
     void callbackMode(QNetworkReply *rep);
     void callbackCloudLog(QNetworkReply *rep);
     void callbackPower();
+    void callbackModeOverride();
     void callbackPropMode();
     void callbackSatellite();
 
@@ -92,6 +93,7 @@ private:
     double txOffset;
     double rxOffset;
     int power;
+    QString modeOverride;
 
     QString settingsFile;
 

--- a/cloudlogcatqt.ui
+++ b/cloudlogcatqt.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>415</width>
-    <height>515</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -21,10 +21,29 @@
     </size>
    </property>
    <layout class="QGridLayout" name="gridLayout">
-    <item row="4" column="0">
+    <item row="5" column="0">
      <widget class="QPushButton" name="save">
       <property name="text">
        <string>Save</string>
+      </property>
+     </widget>
+    </item>
+    <item row="0" column="0">
+     <widget class="QLabel" name="mode">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="maximumSize">
+       <size>
+        <width>50</width>
+        <height>16777215</height>
+       </size>
+      </property>
+      <property name="text">
+       <string>Mode</string>
       </property>
      </widget>
     </item>
@@ -50,26 +69,7 @@
       </property>
      </widget>
     </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="mode">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>50</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Mode</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0" rowspan="2">
+    <item row="2" column="0">
      <layout class="QFormLayout" name="Config">
       <property name="sizeConstraint">
        <enum>QLayout::SetDefaultConstraint</enum>
@@ -126,31 +126,31 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <widget class="QLabel" name="label_8">
         <property name="text">
          <string>Propagation Mode:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <widget class="QComboBox" name="propMode"/>
       </item>
-      <item row="4" column="0">
+      <item row="5" column="0">
        <widget class="QLabel" name="label_9">
         <property name="text">
          <string>Satellite:</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="1">
+      <item row="5" column="1">
        <widget class="QComboBox" name="satellite">
         <property name="enabled">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="label_1">
         <property name="maximumSize">
          <size>
@@ -163,7 +163,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
+      <item row="6" column="1">
        <widget class="QLineEdit" name="FLRigHostname">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
@@ -176,7 +176,7 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="0">
+      <item row="7" column="0">
        <widget class="QLabel" name="label_2">
         <property name="maximumSize">
          <size>
@@ -189,14 +189,14 @@
         </property>
        </widget>
       </item>
-      <item row="6" column="1">
+      <item row="7" column="1">
        <widget class="QLineEdit" name="FLRigPort">
         <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="7" column="0">
+      <item row="8" column="0">
        <widget class="QLabel" name="label_3">
         <property name="maximumSize">
          <size>
@@ -209,14 +209,14 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="1">
+      <item row="8" column="1">
        <widget class="QLineEdit" name="cloudLogUrl">
         <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="8" column="0">
+      <item row="9" column="0">
        <widget class="QLabel" name="label_4">
         <property name="maximumSize">
          <size>
@@ -235,20 +235,30 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="1">
+      <item row="9" column="1">
        <widget class="QLineEdit" name="cloudLogKey">
         <property name="text">
          <string/>
         </property>
        </widget>
       </item>
-      <item row="9" column="1">
-       <widget class="QLineEdit" name="cloudLogIdentifier"/>
-      </item>
-      <item row="9" column="0">
+      <item row="10" column="0">
        <widget class="QLabel" name="label_10">
         <property name="text">
          <string>Cloudlog Identifier:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="10" column="1">
+       <widget class="QLineEdit" name="cloudLogIdentifier"/>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLineEdit" name="ModeOverride"/>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Mode (e.g. FT8):</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
In the case of FT8 flrig will report USB but the logged mode should be FT8. Using the new field FT8 can be entered manually to override the flrig mode.